### PR TITLE
feat: allows creating socks proxy from URI, socks allowed

### DIFF
--- a/KinanCity-core/src/main/java/com/kinancity/core/Configuration.java
+++ b/KinanCity-core/src/main/java/com/kinancity/core/Configuration.java
@@ -150,6 +150,7 @@ public class Configuration {
 				logger.info("All proxies are valid");
 			} else {
 				proxyManager.getProxies().removeAll(invalidProxies);
+				logger.info("{} valid proxies left", proxyManager.getProxies().size());
 			}
 		}
 
@@ -196,27 +197,11 @@ public class Configuration {
 
 			String[] proxyDefs = proxiesConfig.split("[,;]");
 			for (String proxyDef : proxyDefs) {
-				String[] parts = proxyDef.split("[:@]");
-				if (parts.length == 4) {
-					try {
-						// Auth Proxy
-						String host = parts[2];
-						int port = Integer.parseInt(parts[3]);
-						String login = parts[0];
-						String pass = parts[1];
-						proxyManager.addProxy(new ProxyInfo(getProxyPolicyInstance(), new HttpProxy(host, port, login, pass)));
-					} catch (NumberFormatException e) {
-						logger.error("Invalid proxy {}", proxyDef);
-					}
-				} else if (parts.length == 2) {
-					try {
-						// Standard HTTP Proxy
-						String host = parts[0];
-						int port = Integer.parseInt(parts[1]);
-						proxyManager.addProxy(new ProxyInfo(getProxyPolicyInstance(), new HttpProxy(host, port)));
-					} catch (NumberFormatException e) {
-						logger.error("Invalid proxy {}", proxyDef);
-					}
+				HttpProxy proxy = HttpProxy.fromURI(proxyDef.trim());
+				if(proxy == null){
+					logger.error("Invalid proxy {}", proxyDef);
+				}else{
+					proxyManager.addProxy(new ProxyInfo(getProxyPolicyInstance(), proxy));
 				}
 			}
 

--- a/KinanCity-core/src/main/java/com/kinancity/core/proxy/ProxyTester.java
+++ b/KinanCity-core/src/main/java/com/kinancity/core/proxy/ProxyTester.java
@@ -35,7 +35,7 @@ public class ProxyTester {
 			logger.error("Proxy Timed out : {}", e.getMessage());
 			return false;
 		} catch (IOException e) {
-			logger.error("Proxy Test Failed : {}", e.getMessage());
+			logger.debug("Proxy Test Failed : {}", e.getMessage());
 			return false;
 		}
 

--- a/KinanCity-core/src/main/java/com/kinancity/core/proxy/impl/HttpProxy.java
+++ b/KinanCity-core/src/main/java/com/kinancity/core/proxy/impl/HttpProxy.java
@@ -49,18 +49,6 @@ public class HttpProxy implements HttpProxyProvider {
 			"(?::(?<port>\\d{1,5}))?)$";
 
 	/**
-	 * Constructor for a Http Proxy without auth
-	 * 
-	 * @param host
-	 *            ip address or dns
-	 * @param port
-	 *            connection port
-	 */
-	public HttpProxy(String host, int port) {
-		this(host, port, null, null, Type.HTTP);
-	}
-	
-	/**
 	 * Constructor for a Http Proxy with auth
 	 * 
 	 * @param host
@@ -103,6 +91,9 @@ public class HttpProxy implements HttpProxyProvider {
 	 * @return
 	 */
 	public static HttpProxy fromURI(String uri) {
+		if(uri == null){
+			return null;
+		}
 		Matcher matcher = Pattern.compile(URI_REGEXP).matcher(uri);
 		if (matcher.find()) {
 			String host = matcher.group("host");
@@ -147,7 +138,18 @@ public class HttpProxy implements HttpProxyProvider {
 		}
 	}
 
-
+	/**
+	 * Constructor for a Http Proxy without auth
+	 * 
+	 * @param host
+	 *            ip address or dns
+	 * @param port
+	 *            connection port
+	 */
+	public HttpProxy(String host, int port) {
+		this.host = host;
+		this.port = port;
+	}
 
 	@Override
 	public OkHttpClient getClient() {


### PR DESCRIPTION
Allow creating proxies from URI

`protocol :// login : password @ host : port`

all parts are optional. default protocol is http, ports are default ports depending on protocol.

example of socks5 proxy with auth: 

`socks5://username:pass@127.0.0.1:3128`

fixes #11 