### PR TITLE
Boost period to 15 minutes + 1min margin

### DIFF
--- a/KinanCity-core/src/main/java/com/kinancity/core/proxy/policies/NintendoTimeLimitPolicy.java
+++ b/KinanCity-core/src/main/java/com/kinancity/core/proxy/policies/NintendoTimeLimitPolicy.java
@@ -3,7 +3,7 @@ package com.kinancity.core.proxy.policies;
 import lombok.Getter;
 
 /**
- * Policy that limits to 5 accounts every 10 minutes.
+ * Policy that limits to 5 accounts every 15 minutes.
  * 
  * @author drallieiv
  *
@@ -14,8 +14,8 @@ public class NintendoTimeLimitPolicy extends TimeLimitPolicy {
 	// How many account can we create during the time span
 	public static final int NINTENDO_MAX_NB = 5;
 
-	// Period with a 15s safety
-	public static final long NINTENDO_MAX_TIME = 10 * 60 + 15;
+	// Period with a 60s safety
+	public static final long NINTENDO_MAX_TIME = 15 * 60 + 60;
 
 	public NintendoTimeLimitPolicy() {
 		super(NINTENDO_MAX_NB, NINTENDO_MAX_TIME);


### PR DESCRIPTION
HardCoded default values, but GUI will allow people to use their own settings to choose between speed and cost-effectiveness

fix #18 