### PR TITLE
Allow birthdate and country to be set from CSV (fixes #40)

### DIFF
--- a/KinanCity-core/src/main/java/com/kinancity/core/generator/account/CsvHeaderConstants.java
+++ b/KinanCity-core/src/main/java/com/kinancity/core/generator/account/CsvHeaderConstants.java
@@ -5,7 +5,9 @@ public class CsvHeaderConstants {
 	public static final String USERNAME = "username";
 	public static final String EMAIL = "email";
 	public static final String PASSWORD = "password";
-	
+	public static final String DOB = "dob";
+	public static final String COUNTRY = "country";
+
 	private CsvHeaderConstants(){
 		
 	}

--- a/KinanCity-core/src/main/java/com/kinancity/core/generator/account/CsvReaderAccountGenerator.java
+++ b/KinanCity-core/src/main/java/com/kinancity/core/generator/account/CsvReaderAccountGenerator.java
@@ -101,6 +101,15 @@ public class CsvReaderAccountGenerator extends ListAccountGenerator implements A
 		account.setUsername(fieldMap.get(CsvHeaderConstants.USERNAME));
 		account.setPassword(fieldMap.get(CsvHeaderConstants.PASSWORD));
 		account.setEmail(fieldMap.get(CsvHeaderConstants.EMAIL));
+
+		if (fieldMap.containsKey(CsvHeaderConstants.DOB)) {
+			account.setDob(fieldMap.get(CsvHeaderConstants.DOB));
+		}
+
+		if (fieldMap.containsKey(CsvHeaderConstants.COUNTRY)) {
+			account.setCountry(fieldMap.get(CsvHeaderConstants.COUNTRY));
+		}
+
 		return account;
 	}
 }

--- a/ptc-api/src/main/java/com/kinancity/api/PtcSession.java
+++ b/ptc-api/src/main/java/com/kinancity/api/PtcSession.java
@@ -425,8 +425,8 @@ public class PtcSession {
 	// Http Request for age check submit
 	private Request buildAgeCheckSubmitRequest(AccountData account, String csrfToken) throws UnsupportedEncodingException {
 		RequestBody body = new FormBody.Builder()
-				.add("dob", "1985-01-16")
-				.add("country", "US")
+				.add("dob", account.getDob())
+				.add("country", account.getCountry())
 				.add("csrfmiddlewaretoken", csrfToken)
 				.build();
 


### PR DESCRIPTION
Currently you can set `dob` and `country` columns in a CSV, but nothing happens because the values aren't used and the API also overrides them.

This fixes that issue by checking for `dob` and `country` as well as replacing the hard-coded values (in the API module) with whatever's been set on the `account` object.