### PR TITLE
Fixed: UnlimitedProxy getting benched and marked as overlimit

### DIFF
--- a/KinanCity-core/src/main/java/com/kinancity/core/proxy/ProxyManager.java
+++ b/KinanCity-core/src/main/java/com/kinancity/core/proxy/ProxyManager.java
@@ -71,7 +71,7 @@ public class ProxyManager {
 	}
 
 	public void benchProxy(ProxyInfo proxy) {
-		if(proxies.contains(proxy) && !proxyBench.contains(proxy)){
+		if (!(proxy.getProxyPolicy() instanceof UnlimitedUsePolicy) && proxies.contains(proxy) && !proxyBench.contains(proxy)) {
 			proxies.remove(proxy);
 			proxyBench.add(proxy);
 			logger.warn("Proxy [{}] moved out of rotation, {} proxy left",proxy, proxies.size());

--- a/KinanCity-core/src/main/java/com/kinancity/core/proxy/ProxyManager.java
+++ b/KinanCity-core/src/main/java/com/kinancity/core/proxy/ProxyManager.java
@@ -11,6 +11,8 @@ import org.slf4j.LoggerFactory;
 import lombok.Getter;
 import lombok.Setter;
 
+import com.kinancity.core.proxy.policies.UnlimitedUsePolicy;
+
 /**
  * Manager that holds a set of proxies
  * 

--- a/KinanCity-core/src/main/java/com/kinancity/core/proxy/policies/UnlimitedUsePolicy.java
+++ b/KinanCity-core/src/main/java/com/kinancity/core/proxy/policies/UnlimitedUsePolicy.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 /**
  * Ideal unlimited use policy.
  * 
- * Only gets blocked if marked over limit Can be released with reset
+ * Never gets blocked. Always available.
  * 
  * @author drallieiv
  *
@@ -17,26 +17,16 @@ import lombok.Getter;
 @Getter
 public class UnlimitedUsePolicy implements ProxyPolicy {
 
-	private boolean overLimit = false;
-
-	public void reset() {
-		overLimit = false;
-	}
-
-	@Override
-	public void markOverLimit() {
-		overLimit = true;
-	}
-
 	@Override
 	public boolean isAvailable() {
-		return !overLimit;
+		return true;
 	}
-
-	public String toString() {
-		return "unlimited";
+    
+	@Override
+	public void markOverLimit() {
+        	return;
 	}
-
+    
 	@Override
 	public UnlimitedUsePolicy clone() {
 		return new UnlimitedUsePolicy();
@@ -44,10 +34,11 @@ public class UnlimitedUsePolicy implements ProxyPolicy {
 
 	@Override
 	public Optional<ProxySlot> getFreeSlot() {
-		if (overLimit) {
-			return Optional.empty();
-		}
 		return Optional.of(new ProxySlot());
 	}
-
+	
+	public String toString() {
+		return "unlimited";
+	}
+	
 }


### PR DESCRIPTION
Don't bench or mark an UnlimitedProxy as overlimit.
Simply retry.

Test: Created 500 accounts in a few minutes.